### PR TITLE
Fixing build by using valid application ID.

### DIFF
--- a/.github/workflows/template_change_test.yml
+++ b/.github/workflows/template_change_test.yml
@@ -1,0 +1,17 @@
+name: Rename Template
+
+on: pull_request
+
+jobs:
+  rename-template:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+
+      - name: Rename & Build
+        run: ./gradlew renameTemplate build

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ To setup this repository to your needs, open the [setup.gradle](buildscripts/set
 and tweak the `renameConfig` block to your needs. After that, you can run the `renameTemplate` 
 gradle task to have the app module's package name and relevant strings replaced.
 
-Once you've done this, feel free to delete that `setup.gradle` file from your project.
+### Cleanup
+
+Once you've done this, feel free to delete that [setup.gradle](buildscripts/setup.gradle) file from your project. In 
+addition, you can remove the [template_change_test](.github/workflows/template_change_test.yml) 
+workflow which validates the above process for the template repo itself.
 
 ## What's Included
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdk 31
 
     defaultConfig {
-        applicationId "template"
+        applicationId "template.app.id"
         minSdk 21
         targetSdk 31
         versionCode 1

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.template">
+    package="template">
 
     <application
         android:allowBackup="true"

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -1,7 +1,8 @@
 def renameConfig = [
-        templateName: "template",
-        newPackage     : "domain.yourname.app",
-        newProjectName : "Your Project",
+        templateName  : "template",
+        templateAppId : "template.app.id",
+        newPackage    : "domain.yourname.app",
+        newProjectName: "Your Project",
 ]
 
 task renameAppPackage(type: Copy) {
@@ -47,7 +48,7 @@ task replacePackageInManifest {
 
         // Replace package
         file.text = file.text.replaceAll(
-                "package=\"com.${renameConfig.templateName}\"",
+                "package=\"${renameConfig.templateName}\"",
                 "package=\"${renameConfig.newPackage}\"",
         )
 
@@ -67,7 +68,7 @@ task replaceApplicationId {
         def file = new File("${rootDir}/app/build.gradle")
 
         file.text = file.text.replaceAll(
-                "applicationId \"${renameConfig.templateName}\"",
+                "applicationId \"${renameConfig.templateAppId}\"",
                 "applicationId \"${renameConfig.newPackage}\"",
         )
     }


### PR DESCRIPTION
## Summary

* The previous build failed because the app id was invalid. I've changed it.

## How It Was Tested

* Added a template_change_test workflow to run on PR. 