### PR TITLE
Adding Application class

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".TemplateApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/template/TemplateApp.kt
+++ b/app/src/main/java/template/TemplateApp.kt
@@ -1,0 +1,7 @@
+package template
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class TemplateApp : Application()

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -72,6 +72,17 @@ task renameAppPackage(type: Copy) {
         )
     }
 
+    rename { fileName ->
+        if (fileName.contains("${renameConfig.templateApplicationClassName}")) {
+            fileName.replace(
+                    "${renameConfig.templateApplicationClassName}",
+                    "${renameConfig.newApplicationClassName}",
+            )
+        } else {
+            fileName
+        }
+    }
+
     doLast {
         delete(startingDirectory)
     }

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -147,6 +147,7 @@ task keepOrRemoveDependencies {
             if (renameConfig.useHiltDependencies != true) {
                 println("Removing hilt dependencies")
                 removeTextFromFile(fileName, "hilt")
+                removeTextFromFile(fileName, "Hilt")
             }
 
             if (renameConfig.useRoomDependencies != true) {

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -1,14 +1,16 @@
 def renameConfig = [
-        templateName             : "template",
-        templateAppId            : "template.app.id",
-        templateMaterialThemeName: "TemplateTheme",
-        newPackage               : "domain.yourname.app",
-        newProjectName           : "Your Project",
-        newMaterialThemeName     : "MyMaterialTheme",
-        useHiltDependencies      : true,
-        useRoomDependencies      : true,
-        useRetrofitDependencies  : true,
-        usePaparazziDependencies : true,
+        templateName                : "template",
+        templateAppId               : "template.app.id",
+        templateMaterialThemeName   : "TemplateTheme",
+        templateApplicationClassName: "TemplateApp",
+        newPackage                  : "domain.yourname.app",
+        newProjectName              : "Your Project",
+        newMaterialThemeName        : "MyMaterialTheme",
+        newApplicationClassName     : "MyApp",
+        useHiltDependencies         : true,
+        useRoomDependencies         : true,
+        useRetrofitDependencies     : true,
+        usePaparazziDependencies    : true,
 ]
 
 task deleteSetupCode() {
@@ -62,6 +64,14 @@ task renameAppPackage(type: Copy) {
         )
     }
 
+    // Replace application class references
+    filter { line ->
+        line.replaceAll(
+                "${renameConfig.templateApplicationClassName}",
+                "${renameConfig.newApplicationClassName}",
+        )
+    }
+
     doLast {
         delete(startingDirectory)
     }
@@ -76,6 +86,12 @@ task replaceTemplateReferences {
                 "${rootDir}/app/src/main/AndroidManifest.xml",
                 "${renameConfig.templateName}.MainActivity",
                 "${renameConfig.newPackage}.MainActivity",
+        )
+
+        replaceTextInFile(
+                "${rootDir}/app/src/main/AndroidManifest.xml",
+                ".${renameConfig.templateApplicationClassName}",
+                ".${renameConfig.newApplicationClassName}",
         )
 
         replaceTextInFile(

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -140,6 +140,7 @@ task keepOrRemoveDependencies {
                 "${rootDir}/build.gradle.kts",
                 "${rootDir}/app/build.gradle.kts",
                 "${rootDir}/gradle/libs.versions.toml",
+                "${rootDir}/app/src/main/java/template/TemplateApp.kt",
         ]
 
         filesWithDependencies.each { fileName ->


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

The Application class is used to configure a lot of app wide things, like hilt, logging, third party SDKs, etc. Having this as part of the template can save a lot of time. 

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

CI passing on renaming and such. Also manually renamed to verify how it worked even with Hilt updates. 
