### PR TITLE
Adding Compose build features back

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,10 @@ android {
         jvmTarget = "17"
     }
 
+    buildFeatures {
+        compose = true
+    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"


### PR DESCRIPTION
This got removed in the K2 PR, but I noticed since removing this that I no longer have AS previews for Compose lmao. Adding back in.