### PR TITLE
Ignoring build folder for kotlinter tasks.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,3 +89,11 @@ dependencies {
     androidTestImplementation(libs.compose.ui.test.junit)
     androidTestImplementation(libs.hilt.android.testing)
 }
+
+tasks.formatKotlinMain {
+    exclude { it.file.path.contains("build/")}
+}
+
+tasks.lintKotlinMain {
+    exclude { it.file.path.contains("build/")}
+}


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

This makes it so the kotlinter tasks don't fail for auto generated code. 
