### PR TITLE
Adding a BasePaparazziTest helper.

### DIFF
--- a/.github/workflows/template_change_test.yml
+++ b/.github/workflows/template_change_test.yml
@@ -45,7 +45,9 @@ jobs:
         uses: gradle/gradle-build-action@v3
 
       - name: Rename
-        run: ./gradlew renameTemplate formatKotlin
+        run: |
+            ./gradlew renameTemplate 
+            ./gradlew formatKotlin
 
       - name: Build
         run: ./gradlew build

--- a/.github/workflows/template_change_test.yml
+++ b/.github/workflows/template_change_test.yml
@@ -45,7 +45,7 @@ jobs:
         uses: gradle/gradle-build-action@v3
 
       - name: Rename
-        run: ./gradlew renameTemplate
+        run: ./gradlew renameTemplate formatKotlin
 
       - name: Build
         run: ./gradlew build

--- a/.github/workflows/template_change_test.yml
+++ b/.github/workflows/template_change_test.yml
@@ -45,9 +45,7 @@ jobs:
         uses: gradle/gradle-build-action@v3
 
       - name: Rename
-        run: |
-            ./gradlew renameTemplate 
-            ./gradlew formatKotlin
+        run: ./gradlew renameTemplate
 
       - name: Build
         run: ./gradlew build

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
 
     annotationProcessor(libs.androidx.room.compiler)
 
+    testImplementation(libs.google.testparameterinjector)
     testImplementation(libs.junit)
 
     androidTestImplementation(platform(libs.compose.bom))

--- a/app/src/test/java/template/BasePaparazziTest.kt
+++ b/app/src/test/java/template/BasePaparazziTest.kt
@@ -1,0 +1,44 @@
+package template
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import app.cash.paparazzi.Paparazzi
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import org.junit.Rule
+import org.junit.runner.RunWith
+import template.theme.TemplateTheme
+
+/**
+ * This base class allows us to write Paparazzi tests that validate composable content in both light and dark theme
+ * using a parameterized test. Just extend this base class and call [snapshot] with your composable content.
+ */
+@RunWith(TestParameterInjector::class)
+abstract class BasePaparazziTest {
+    @get:Rule
+    @Suppress("ktlint:standard:backing-property-naming")
+    val _paparazzi = Paparazzi()
+
+    @TestParameter
+    val useDarkTheme: Boolean = false
+
+    /**
+     * Validates the supplied [content] in both light and dark theme.
+     */
+    fun snapshot(content: @Composable () -> Unit) {
+        _paparazzi.snapshot {
+            TemplateTheme(
+                darkTheme = useDarkTheme,
+            ) {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxSize(),
+                ) {
+                    content()
+                }
+            }
+        }
+    }
+}

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -37,13 +37,73 @@ task deleteSetupCode() {
     }
 }
 
-task renameAppPackage(type: Copy) {
-    description "Renames the template package in the app module."
+task renameAppMainPackage(type: Copy) {
+    description "Renames the template package in the app/src/main module."
     group null
 
     def newPackageAsDirectory = renameConfig.newPackage.replaceAll("\\.", "/")
     def startingDirectory = "${rootDir}/app/src/main/java/${renameConfig.templateName}"
     def endingDirectory = "${rootDir}/app/src/main/java/${newPackageAsDirectory}"
+
+    from(startingDirectory)
+    into(endingDirectory)
+
+    // Replace package statements
+    filter { line ->
+        line.replaceAll(
+                "package ${renameConfig.templateName}",
+                "package ${renameConfig.newPackage}"
+        )
+    }
+
+    // Replace import statements
+    filter { line ->
+        line.replaceAll(
+                "import ${renameConfig.templateName}",
+                "import ${renameConfig.newPackage}"
+        )
+    }
+
+    // Replace Theme references. We can just replace on name,
+    // which covers both imports and function calls.
+    filter { line ->
+        line.replaceAll(
+                "${renameConfig.templateMaterialThemeName}",
+                "${renameConfig.newMaterialThemeName}"
+        )
+    }
+
+    // Replace application class references
+    filter { line ->
+        line.replaceAll(
+                "${renameConfig.templateApplicationClassName}",
+                "${renameConfig.newApplicationClassName}",
+        )
+    }
+
+    rename { fileName ->
+        if (fileName.contains("${renameConfig.templateApplicationClassName}")) {
+            fileName.replace(
+                    "${renameConfig.templateApplicationClassName}",
+                    "${renameConfig.newApplicationClassName}",
+            )
+        } else {
+            fileName
+        }
+    }
+
+    doLast {
+        delete(startingDirectory)
+    }
+}
+
+task renameAppTestPackage(type: Copy) {
+    description "Renames the template package in the app/src/test module."
+    group null
+
+    def newPackageAsDirectory = renameConfig.newPackage.replaceAll("\\.", "/")
+    def startingDirectory = "${rootDir}/app/src/test/java/${renameConfig.templateName}"
+    def endingDirectory = "${rootDir}/app/src/test/java/${newPackageAsDirectory}"
 
     from(startingDirectory)
     into(endingDirectory)
@@ -184,7 +244,8 @@ task renameTemplate {
 
     dependsOn(
             keepOrRemoveDependencies,
-            renameAppPackage,
+            renameAppMainPackage,
+            renameAppTestPackage,
             replaceTemplateReferences,
             deleteSetupCode,
     )

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -233,6 +233,9 @@ task keepOrRemoveDependencies {
             if (renameConfig.usePaparazziDependencies != true) {
                 println("Removing paparazzi dependencies")
                 removeTextFromFile(fileName, "paparazzi")
+
+                def testHelper = "${rootDir}/app/src/test/java/${renameConfig.templateName}/BasePaparazziTest.kt"
+                delete(testHelper)
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ paparazzi = "1.3.4"
 retrofit = "2.11.0"
 room = "2.6.1"
 sortDependencies = "0.8"
+testParameterInjector = "1.18"
 
 [libraries]
 android-material = { module = "com.google.android.material:material", version.ref = "material" }
@@ -44,6 +45,7 @@ compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 compose-ui-util = { group = "androidx.compose.ui", name = "ui-util" }
 detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detektGradlePlugin" }
+google-testparameterinjector = { module = "com.google.testparameterinjector:test-parameter-injector", version.ref = "testParameterInjector" }
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 gradle-versions-plugin = { module = "com.github.ben-manes:gradle-versions-plugin", version.ref = "gradleVersionsPlugin" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Helper base class automatically tests Composable content in light/dark mode. Also adds a GitHub action to validate paparazzi tests.

All of this can be removed if user elects not to use paparazzi via the setup.gradle file. 

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

CI passing should verify everything here
