### PR TITLE
Using mustRunAfter instead of dependsOn for formatting task in setup.

### DIFF
--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -183,7 +183,7 @@ project('app').tasks.named {
     // like formatKotlinMain, formatKotlinTest, etc.
     it.startsWith("formatKotlin")
 }.configureEach {
-    dependsOn(rootProject.tasks.named("renameTemplate"))
+    mustRunAfter(rootProject.tasks.named("renameTemplate"))
 }
 
 task renameTemplate {


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

We don't want formatting to depend on setup, because otherwise formatting the template repo runs the rename lol. We want mustRunAfter, which means if they're together, formatting must run at the end. 
