### PR TITLE
Separating XR and XR-Material dependencies.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ retrofit = "2.11.0"
 room = "2.6.1"
 sortDependencies = "0.14"
 xr = "1.0.0-alpha03"
+xr-material = "1.0.0-alpha05"
 
 [libraries]
 android-material = { module = "com.google.android.material:material", version.ref = "material" }
@@ -37,7 +38,7 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTest" }
 androidx-xr-compose = { module = "androidx.xr.compose:compose", version.ref = "xr" }
-androidx-xr-compose-material3 = { module = "androidx.xr.compose.material3:material3", version.ref = "xr" }
+androidx-xr-compose-material3 = { module = "androidx.xr.compose.material3:material3", version.ref = "xr-material" }
 androidx-xr-scenecore = { module = "androidx.xr.scenecore:scenecore", version.ref = "xr" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Some renovate updates are failing because not all XR deps are on the same cadence. 
