### PR TITLE
Updating detekt config for UnusedPrivateMember. 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,7 @@ insert_final_newline = true
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
 ktlint_function_naming_ignore_when_annotated_with = Composable
+# 2 is the default, but setting it to 1 forces all params on a multiline no matter what.
+ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than = 2
 ktlint_standard_multiline-expression-wrapping = disabled
 ktlint_standard_string-template-indent = disabled

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -2,6 +2,8 @@
 # want to override for our application. This is done by using `buildUponDefaultConfig` in the gradle
 # configuration.
 
+# You can find a list of rules in the Detekt docs: https://detekt.dev/docs/intro
+
 naming:
   active: true
   # Ignore function naming for Composable functions since they start with uppercase letters.

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -4,9 +4,18 @@
 
 naming:
   active: true
+  # Ignore function naming for Composable functions since they start with uppercase letters.
   FunctionNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
     functionPattern: '[a-z][a-zA-Z0-9]*'
     excludeClassPattern: '$^'
     ignoreAnnotated: ['Composable']
+
+style:
+  active: true
+  # If a preview function is private and unused, Detekt flags that by default.AlsoCouldBeApply:
+  # Disable this check if the function is annotated with Preview.
+  UnusedPrivateMember:
+    active: true
+    ignoreAnnotated: ['Preview']


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Typically I use private preview functions so they can't be called on accident, and Detekt doesn't like that, so I'm modifying the default config in the template. 
